### PR TITLE
docs: add code review notes from lint and hooks audit

### DIFF
--- a/REVIEW_NOTES.md
+++ b/REVIEW_NOTES.md
@@ -1,0 +1,44 @@
+# Code Review Notes (May 18, 2026)
+
+This review focused on static checks and a quick architecture pass for the Next.js portfolio app.
+
+## What I ran
+
+- `npm run lint`
+
+## Key findings
+
+### 1) React Hooks rule violations are currently blocking lint
+These are the highest-priority items because they fail CI-quality linting and may hide runtime issues.
+
+- `app/components/LocalTime.tsx`: synchronous `setMounted(true)` inside an effect (`react-hooks/set-state-in-effect`).
+- `app/components/Navbar.tsx`: synchronous `setIsMenuOpen(false)` inside an effect keyed on route changes.
+- `app/components/SpotifyNowPlaying.tsx`: mutation/reassignment pattern (`x ^= ...`) flagged by `react-hooks/immutability`.
+- `app/components/ui/HyperText.tsx`: component factory (`motion.create`) created during render path, flagged as `react-hooks/static-components`.
+- `app/components/ui/flip-word.tsx`: synchronous `setMounted(true)` in effect.
+- `components/fancy/text/vertical-cut-reveal.tsx`: memoization dependency mismatch (`preserve-manual-memoization`) and effect calling animation state update path (`set-state-in-effect`).
+
+### 2) Hook dependency hygiene warnings
+Not immediate blockers, but should be cleaned up to avoid stale-closure bugs.
+
+- `app/components/ui/typewriter-effect.tsx`: missing `animate` dependency.
+- `components/fancy/text/vertical-cut-reveal.tsx`: missing `elements`, `splitBy`, and `startAnimation` dependencies in hooks.
+
+### 3) Unused disable comments
+A few `eslint-disable` directives are no longer needed and can be removed.
+
+- `app/blogs/[slug]/page.tsx`
+- `app/components/SpotifyNowPlaying.tsx`
+
+## Suggested remediation order
+
+1. Fix all `react-hooks/set-state-in-effect` violations first.
+2. Refactor `HyperText` so the motion component is statically declared outside render or via a safe pattern accepted by the rule.
+3. Refactor `SpotifyNowPlaying` random generator logic to avoid mutable post-render local reassignment.
+4. Resolve `vertical-cut-reveal` callback dependencies by matching inferred dependencies (or simplify by removing manual memoization where unnecessary).
+5. Remove obsolete eslint-disable comments and re-run lint.
+
+## Current status
+
+- Lint result: **failed** (8 errors, 6 warnings).
+- App health: likely functionally usable, but code quality gates are not passing due to hook/compiler rules.


### PR DESCRIPTION
### Motivation
- Document the results of running `npm run lint` and capture blocking React Hooks/compiler lint issues with a clear remediation priority so follow-up fixes can be implemented systematically.

### Description
- Add `REVIEW_NOTES.md` that summarizes the `npm run lint` output, lists the highest-priority failures (e.g., `react-hooks/set-state-in-effect`, `react-hooks/immutability`, `react-hooks/static-components`, and memoization dependency mismatches), notes secondary hook dependency warnings, and provides a suggested remediation order.

### Testing
- Ran `npm run lint`, which produced 8 errors and 6 warnings (lint failed), and the results are recorded in `REVIEW_NOTES.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a9f23a40c832bbe74f54ca80160c5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added review documentation capturing code quality assessment and remediation plan for the Next.js portfolio app.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Rohit-48/portfolio/pull/4?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->